### PR TITLE
[UIMA-6254] Move API report post-analysis script into the build resources

### DIFF
--- a/src/main/resources/japicmp/api-report.groovy
+++ b/src/main/resources/japicmp/api-report.groovy
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+  def it = jApiClasses.iterator()
+  while (it.hasNext()) {
+    def jApiClass = it.next()
+    def fqn = jApiClass.getFullyQualifiedName()
+    if (fqn.contains(".impl.") || 
+        fqn.contains(".internal.") ||
+        fqn.endsWith("_Type") 
+       ) {
+      it.remove()
+    }
+  }  
+  return jApiClasses


### PR DESCRIPTION
**JIRA Ticket:** https://issues.apache.org/jira/browse/UIMA-UIMA-6254

**What's in the PR**
- Added api-report.groovy script from UIMA Java SDK to the general build resources

**How to test manually**
* No test procedure

**Automatic testing**
* [ ] *PR adds/updates unit tests*

**Documentation**
* [ ] *PR adds/updates documentation*

**Organizational**
- [ ] *PR includes new dependencies.* Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed.
      LICENSE and NOTICE files in the respective modules where dependencies have been added as
      well as in the project root have been updated.
